### PR TITLE
Optimize traces a bit by not getting a new Date for each.

### DIFF
--- a/src/backend/opbeat_backend.js
+++ b/src/backend/opbeat_backend.js
@@ -120,7 +120,7 @@ function groupTraces (traces) {
       transaction: trace.transaction.name,
       signature: trace.signature,
       kind: trace.type,
-      timestamp: trace._startStamp.toISOString(),
+      timestamp: trace.transaction._startStamp.toISOString(),
       parents: trace.ancestors(),
       extra: extra,
       _group: key
@@ -153,7 +153,7 @@ function groupingTs (ts) {
 
 function transactionGroupingKey (trans) {
   return [
-    groupingTs(trans._startStamp).getTime(),
+    groupingTs(trans.transaction._startStamp).getTime(),
     trans.name,
     trans.result,
     trans.type
@@ -166,7 +166,7 @@ function traceGroupingKey (trace) {
   }).join(',')
 
   return [
-    groupingTs(trace._startStamp).getTime(),
+    groupingTs(trace.transaction._startStamp).getTime(),
     trace.transaction.name,
     ancestors,
     trace.signature,

--- a/src/instrumentation/index.js
+++ b/src/instrumentation/index.js
@@ -128,7 +128,7 @@ function groupTraces (traces) {
       transaction: trace.transaction.name,
       signature: trace.signature,
       kind: trace.type,
-      timestamp: trace._startStamp.toISOString(),
+      timestamp: trace.transaction._startStamp.toISOString(),
       parents: trace.ancestors(),
       extra: {
         _frames: trace.frames
@@ -176,7 +176,7 @@ function traceGroupingKey (trace) {
   }).join(',')
 
   return [
-    groupingTs(trace._startStamp).getTime(),
+    groupingTs(trace.transaction._startStamp).getTime(),
     trace.transaction.name,
     ancestors,
     trace.signature,

--- a/src/transaction/trace.js
+++ b/src/transaction/trace.js
@@ -14,7 +14,6 @@ function Trace (transaction, signature, type, options) {
 
   // Start timers
   this._start = window.performance.now()
-  this._startStamp = new Date()
 
   this._isFinish = new Promise(function (resolve, reject) {
     this._markFinishedFunc = resolve

--- a/src/transaction/transaction.js
+++ b/src/transaction/transaction.js
@@ -28,7 +28,7 @@ var Transaction = function (name, type, options) {
 
   // A transaction should always have a root trace spanning the entire transaction.
   this._rootTrace = this.startTrace('transaction', 'transaction', {enableStackFrames: false})
-  this._startStamp = this._rootTrace._startStamp
+  this._startStamp = new Date()
   this._start = this._rootTrace._start
 
   this.duration = this._rootTrace.duration.bind(this._rootTrace)
@@ -151,10 +151,7 @@ Transaction.prototype._adjustStartToEarliestTrace = function () {
 
   if (trace) {
     this._rootTrace._start = trace._start
-    this._rootTrace._startStamp = trace._startStamp
     this._rootTrace.calcDiff()
-
-    this._startStamp = this._rootTrace._startStamp
     this._start = this._rootTrace._start
   }
 }


### PR DESCRIPTION
We can just use the timestamp from the parent transaction.